### PR TITLE
Fix path for WireGuard config template

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,12 +32,12 @@
 
 - name: Update template and copy to destination server
   template:
-    src: templates/wg/wg0.conf.j2
+    src: templates/wg0.conf.j2
     dest: /etc/wireguard/wg0.conf
 
 - name: Enable ipv4 forwarding via sysctl
   copy:
-    src: templates/wg/99-custom.conf.j2
+    src: templates/99-custom.conf.j2
     dest: /etc/sysctl.d/99-custom.conf
     owner: root
     group: root


### PR DESCRIPTION
This MR fixes the path for WireGuard config template. In [`tasks/main.yml`](https://github.com/acavella/ansible-role-wireguard/blob/4d2f256d50b04d6faca65370d43db44228f1b0b8/tasks/main.yml) the `src` path is `templates/wg/wg0.conf.j2` but in the repo the path is [`templates/wg0.conf.j2`](https://github.com/acavella/ansible-role-wireguard/blob/4d2f256d50b04d6faca65370d43db44228f1b0b8/templates/wg0.conf.j2).

This mismatch in path causes the following error in when running the role:

```
TASK [acavella.wireguard : Decode keys] ***************************************************************************************************************
ok: [ansible.host.tld]

TASK [acavella.wireguard : Update template and copy to destination server] ****************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: If you are using a module and expect the file to exist on the remote, see the remote_src option
fatal: [ansible.host.tld]: FAILED! => {"changed": false, "msg": "Could not find or access 'templates/wg/wg0.conf.j2'\nSearched in:\n\t/home/user/project/.ansible_roles/acavella.wireguard/templates/templates/wg/wg0.conf.j2\n\t/home/user/project/.ansible_roles/acavella.wireguard/templates/wg/wg0.conf.j2\n\t/home/user/project/.ansible_roles/acavella.wireguard/tasks/templates/templates/wg/wg0.conf.j2\n\t/home/user/project/.ansible_roles/acavella.wireguard/tasks/templates/wg/wg0.conf.j2\n\t/home/user/project/templates/templates/wg/wg0.conf.j2\n\t/home/user/project/templates/wg/wg0.conf.j2 on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}

PLAY RECAP ********************************************************************************************************************************************
ansible.host.tld              : ok=6    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

readable error message:
```
"changed": false, "msg": "Could not find or access 'templates/wg/wg0.conf.j2'
Searched in:
        /home/user/project/.ansible_roles/acavella.wireguard/templates/templates/wg/wg0.conf.j2
        /home/user/project/.ansible_roles/acavella.wireguard/templates/wg/wg0.conf.j2
        /home/user/project/.ansible_roles/acavella.wireguard/tasks/templates/templates/wg/wg0.conf.j2
        /home/user/project/.ansible_roles/acavella.wireguard/tasks/templates/wg/wg0.conf.j2
        /home/user/project/templates/templates/wg/wg0.conf.j2
        /home/user/project/templates/wg/wg0.conf.j2 on the Ansible Controller.
If you are using a module and expect the file to exist on the remote, see the remote_src option"

```